### PR TITLE
Update BatchSegmentationWindow.py with segment times functionality

### DIFF
--- a/release/Measurements/Voice_onset/main_Onsets.py
+++ b/release/Measurements/Voice_onset/main_Onsets.py
@@ -222,12 +222,13 @@ def rms(sig,fs,factor=2):
     p = RMS value of x
     p0 = 20uPA = 0.00002 Hearing threshold
     """
-    win_time = 0.025#The size of the frames is fixed to 25ms
-    #The time resolution (step size) is controlled with "factor"
+    step_time = 0.001#The size of the step size (time resolution) is fixed to 1ms
+    #win_time = 0.025#The size of the frames is fixed to 25ms
+    #The window length (window size of frames) is controlled with "factor"
     if factor == 0:
-        step_time = 0.001 #1ms time resolution
+        win_time = 0.001 #1ms time resolution
     else:
-        step_time = 0.005*factor
+        win_time = 0.02*factor
     #Set a threshold based on the energy of the signal
     if len(sig)>3*int(win_time*fs):
         frames = extract_windows(sig,int(win_time*fs),int(step_time*fs))


### PR DESCRIPTION
I added in the functionality of detecting the start, end and duration of each automatically detected segment. These measurements now appear in the output spreadsheet. I also altered the default segment to 200 ms.
I have a few debuging print() things in there, maybe these won't be required. I am not sure of the standard way of doing this!
I suppose this functionality would also be useful for the manual Segmentation Window script too.